### PR TITLE
Integrate shoelace into astro

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,9 @@ export default defineConfig({
   integrations: [react()],
 
   vite: {
-    plugins: [tailwindcss()]
+    plugins: [
+      tailwindcss(),
+    ]
   },
 
   adapter: vercel()

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "@types/react-scroll": "^1.8.10"
   },
   "overrides": {
-  "path-to-regexp": "^6.2.3"
+    "path-to-regexp": "^6.2.3"
   }
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,6 +32,9 @@ import '/src/styles/global.css';
 	</body>
 </html>
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/cdn/themes/light.css" />
+<script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/cdn/shoelace-autoloader.js"></script>
+
 <style is:global>
 	html,
 	body {


### PR DESCRIPTION
Integrating sholeace with astro using the [official documentation](https://shoelace.style/tutorials/integrating-with-astro) causes `npm run dev` to take 30min to load. I think its because it always copies all of astros assets into the `public` folder when building. So now just using CDN but it might cause ["Flash of Undefined Elements"](https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/). If CDN doesn't work can run the copy of the assets into public folder once then disable it but means need to copy again if we want to use new components from shoelace, can also check out this [forum post](https://github.com/shoelace-style/shoelace/discussions/2031#discussioncomment-9560258) too